### PR TITLE
Update Android Dumps source

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ drwxr-xr-x 2 samuel users  4096 Sep 29 12:34 kernel
 Where OEM and DEVICE represent values found (for the moment) at the *Android
 Dumps* project.
 
- * https://git.rip/dumps/
+ * https://dumps.tadiphone.dev/dumps
 
 The output of this is a directory in your `$PWD` named `$OEM-$DEVICE` which
 holds the skeleton generated files.

--- a/lib/autoport/download.rb
+++ b/lib/autoport/download.rb
@@ -16,6 +16,6 @@ module Autoport::Download
 
   def head_blob_url(path)
     prefix = "#{Autoport.oem}/#{Autoport.device}"
-    "https://git.rip/dumps/#{prefix}/-/raw/HEAD/#{path}?inline=false"
+    "https://dumps.tadiphone.dev/dumps/#{prefix}/-/raw/HEAD/#{path}?inline=false"
   end
 end


### PR DESCRIPTION
[git.rip](http://git.rip) has been taken down:

![iprc_seized_banner](https://user-images.githubusercontent.com/382041/111479775-ad7b6c80-8707-11eb-956f-26278d332304.png)

The repo is now available at https://dumps.tadiphone.dev/dumps.

See https://github.com/AndroidDumps/New-Home/commit/89f9cd12cb155169f316202ca48f87b65baa98cb